### PR TITLE
Auto load modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 d-codemirror
 ==================
 
-Example CodeMirror Derby component.  
+Example CodeMirror Derby component.
 
 # Usage
 [Example usage](http://github.com/codeparty/derby-examples/tree/master/codemirror)
@@ -9,7 +9,7 @@ Example CodeMirror Derby component.
 ## In your template
 ```
 <Head:>
-  <view name="d-codemirror:includes"></view>
+  <view name="d-codemirror:includes" static="/cm"></view>
 <Body:>
   <view name="d-codemirror" text={{_page.text}} options="{{ { tabSize: 2 } }}"></view>
 ```
@@ -18,5 +18,18 @@ Example CodeMirror Derby component.
 ```
 model.set("_page.text", "Hello World");
 ```
+
+## Your CodeMirror
+
+You can serve the CodeMirror files from your public folder. If you install them through NPM
+you will have to add an extra static route to your Express app:
+
+````
+var expressApp = express()
+  (…)
+  .use('/cm', serveStatic(process.cwd() + '/node_modules/d-codemirror/node_modules/codemirror/'))
+  (…)
+````
+
 See the [derby-examples](http://github.com/codeparty/derby-examples/tree/master/codemirror)
 repo for an example using real-time data subscriptions to power multi-player editing.

--- a/index.html
+++ b/index.html
@@ -4,5 +4,10 @@
   </div>
 
 <includes:>
-  <link rel="stylesheet" href="{{@static}}/codemirror.css">
-  <script type="text/javascript" src="{{@static}}/codemirror.js"></script>
+  <link rel="stylesheet" href="{{@static}}/lib/codemirror.css">
+  <script type="text/javascript" src="{{@static}}/lib/codemirror.js"></script>
+  <script type="text/javascript">
+      CodeMirror.modeURL = "{{@static}}/mode/%N/%N.js";
+  </script>
+  <script type="text/javascript" src="{{@static}}/addon/mode/loadmode.js"></script>
+  <script type="text/javascript" src="{{@static}}/mode/meta.js"></script>

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 module.exports = CM;
 function CM() {}
 CM.prototype.view = __dirname;
@@ -12,8 +11,23 @@ CM.prototype.create = function() {
   var model = this.model;
   var that = this;
 
-  var options = model.get("options");
+  var options = this.getAttribute("options");
   var cm = this.cm = CodeMirror.fromTextArea(this.textarea, options);
+
+  // Dynamically load necessary files for the CodeMirror mode set through the mode option
+  // Mode can either be a mime-type `text/html` or a CodeMirror mode-name `htmlmixed`
+  // cf. http://codemirror.net/demo/loadmode.html
+
+  if (options.mode) {
+    var mode = options.mode;
+    if (/\//.test(options.mode)) {
+      var info = CodeMirror.findModeByMIME(options.mode);
+      if (info) {
+        mode = info.mode;
+      }
+    }
+    CodeMirror.autoLoadMode(cm, mode);
+  }
 
   // changes in values inside the array
   model.on("change", "text", function(oldVal, newVal, passed) {

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ CM.prototype.create = function() {
       that.supress = false;
       that.check();
     }
-  })
+  });
   cm.on("change", function(cm, change) {
     if(that.supress) return;
     //console.log("change", change)
@@ -43,7 +43,7 @@ CM.prototype.create = function() {
     if(change.removed.length > 1 || change.removed) {
       var toRemove = change.removed.join("\n");
       //console.log("toremove", toRemove, start)
-      model.pass({editing: true }).stringRemove("text", start, toRemove.length)
+      model.pass({editing: true }).stringRemove("text", start, toRemove.length);
     }
     //see if we have anything to insert
     if(change.text.length > 1 || change.text) {
@@ -52,7 +52,7 @@ CM.prototype.create = function() {
       model.pass({editing: true }).stringInsert("text", start, toInsert);
     }
     that.check();
-  })
+  });
 };
 
 CM.prototype.check = function() {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Ian Johnson",
   "license": "MIT",
   "dependencies": {
-    "codemirror": "^4.1.0"
+    "codemirror": "^4.8.0"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
This PR dynamically loads the necessary files for the CodeMirror mode set through the `mode` option, where mode can either be a mime-type `text/html` or a CodeMirror mode-name `htmlmixed`.

The code was partly based on http://codemirror.net/demo/loadmode.html and requires a new version of CodeMirror (bumped here).

In this way, the component becomes easier set up. Otherwise, the developer would have to include the JavaScript files specific to the mode used in addition to instantiating the component. The PR also allows a scenario where the editor can switch between editing various kinds of documents.

Of course this might be suboptimal if the app is using only one mode, and the developer doesn’t mind setting up the extra `<script></script>` tags. What do you think?
